### PR TITLE
Made encoding keyword backward compatible

### DIFF
--- a/reconnecting_ftp/__init__.py
+++ b/reconnecting_ftp/__init__.py
@@ -82,8 +82,13 @@ class Client:
                  max_reconnects: int = 10,
                  timeout: int = 10,
                  FTP=ftplib.FTP,
-                 encoding: str = 'utf-8') -> None:
+                 encoding: str = None) -> None:
         # pylint: disable=too-many-arguments
+        if encoding:
+            if sys.version_info < (3, 9):
+                raise TypeError("encoding argument not supported by ftplib.FTP before Python 3.9")
+            else:
+                self.encoding = encoding
         self.access = Access()
         self.access.hostname = hostname
         self.access.port = port
@@ -92,7 +97,6 @@ class Client:
 
         self.connection = None  # type: Optional[ftplib.FTP]
         self.last_pwd = None  # type: Optional[str]
-        self.encoding = encoding
         self.max_reconnects = max_reconnects
         self.timeout = timeout
 
@@ -113,7 +117,7 @@ class Client:
         if self.connection is None:
             conn_refused = None  # type: Optional[ConnectionRefusedError]
             try:
-                if sys.version_info >= (3, 9):
+                if hasattr(self, 'encoding'):
                     self.connection = self.FTP(timeout=self.timeout, encoding=self.encoding)
                 else:
                     self.connection = self.FTP(timeout=self.timeout)

--- a/reconnecting_ftp/__init__.py
+++ b/reconnecting_ftp/__init__.py
@@ -3,6 +3,7 @@
 Classes helping inputries to download from FTP servers.
 """
 
+import sys
 import ftplib
 import socket
 from typing import Optional, Callable, TypeVar, Union, List, Iterable, Tuple, Dict, Any  # pylint: disable=unused-import
@@ -116,13 +117,6 @@ class Client:
                     self.connection = self.FTP(timeout=self.timeout, encoding=self.encoding)
                 else:
                     self.connection = self.FTP(timeout=self.timeout)
-                    self.connection = self.FTP(timeout=self.timeout, encoding=self.encoding)
-                except TypeError as e:
-                    # The encoding argument was added in Python 3.9.
-                    if str(e).endswith("unexpected keyword argument 'encoding'"):
-                        self.connection = self.FTP(timeout=self.timeout)
-                    else:
-                        raise
                 self.connection.connect(host=self.access.hostname, port=self.access.port)
                 self.connection.login(user=self.access.user, passwd=self.access.password)
             except ConnectionRefusedError as err:

--- a/reconnecting_ftp/__init__.py
+++ b/reconnecting_ftp/__init__.py
@@ -112,7 +112,14 @@ class Client:
         if self.connection is None:
             conn_refused = None  # type: Optional[ConnectionRefusedError]
             try:
-                self.connection = self.FTP(timeout=self.timeout, encoding=self.encoding)
+                try:
+                    self.connection = self.FTP(timeout=self.timeout, encoding=self.encoding)
+                except TypeError as e:
+                    # The encoding argument was added in Python 3.9.
+                    if str(e).endswith("unexpected keyword argument 'encoding'"):
+                        self.connection = self.FTP(timeout=self.timeout)
+                    else:
+                        raise
                 self.connection.connect(host=self.access.hostname, port=self.access.port)
                 self.connection.login(user=self.access.user, passwd=self.access.password)
             except ConnectionRefusedError as err:

--- a/reconnecting_ftp/__init__.py
+++ b/reconnecting_ftp/__init__.py
@@ -112,7 +112,10 @@ class Client:
         if self.connection is None:
             conn_refused = None  # type: Optional[ConnectionRefusedError]
             try:
-                try:
+                if sys.version_info >= (3, 9):
+                    self.connection = self.FTP(timeout=self.timeout, encoding=self.encoding)
+                else:
+                    self.connection = self.FTP(timeout=self.timeout)
                     self.connection = self.FTP(timeout=self.timeout, encoding=self.encoding)
                 except TypeError as e:
                     # The encoding argument was added in Python 3.9.


### PR DESCRIPTION
The `encoding` parameter for ftplib.FTP was [added in Python 3.9](https://docs.python.org/3/library/ftplib.html).

The update to [add the `encoding` parameter](https://github.com/Parquery/reconnecting-ftp/pull/5) broke backward compatibility with versions earlier than 3.9 (they raise an unexpected keyword error).

This pull request modifies the code so that if the `encoding` parameter is not supported, it fails back to a version of the FTP constructor without the `encoding` parameter.
