### PR TITLE
Removed support for Python 3.6 and added for 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-major-version: [ 3 ]
+        python-minor-version: [ 7, 8, 9, 10, 11 ]
 
     steps:
       - uses: actions/checkout@master
@@ -20,7 +21,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ format('{0}.{1}', matrix.python-major-version, matrix.python-minor-version) }}
 
       - name: Install dependencies
         run: |
@@ -33,6 +34,8 @@ jobs:
           python3 precommit.py
 
       - name: Upload Coverage
+        # Python 3.7 has problems with coverage.
+        if: ${{ matrix.python-minor-version > 7 }}
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/precommit.py
+++ b/precommit.py
@@ -99,8 +99,9 @@ def check(path: pathlib.Path, py_dir: pathlib.Path, overwrite: bool) -> Union[No
 
     # yapf
     if not overwrite:
-        formatted, _, changed = yapf.yapflib.yapf_api.FormatFile(
-            filename=str(path), style_config=str(style_config), print_diff=True)
+        formatted, _, changed = yapf.yapflib.yapf_api.FormatFile(filename=str(path),
+                                                                 style_config=str(style_config),
+                                                                 print_diff=True)
 
         if changed:
             report.append(f"Failed to yapf {path}:\n{formatted}")
@@ -108,11 +109,10 @@ def check(path: pathlib.Path, py_dir: pathlib.Path, overwrite: bool) -> Union[No
         yapf.yapflib.yapf_api.FormatFile(filename=str(path), style_config=str(style_config), in_place=True)
 
     # mypy
-    with subprocess.Popen(
-        ['mypy', str(path), '--ignore-missing-imports'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True) as proc:
+    with subprocess.Popen(['mypy', str(path), '--ignore-missing-imports'],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE,
+                          universal_newlines=True) as proc:
         stdout, stderr = proc.communicate()
         if proc.returncode != 0:
             report.append(f"Failed to mypy {path}:\nOutput:\n{stdout}\n\nError:\n{stderr}")
@@ -139,11 +139,10 @@ def main() -> int:
     """
     # pylint: disable=too-many-locals
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--overwrite",
-        help="Overwrites the unformatted source files with the well-formatted code in place. "
-        "If not set, an exception is raised if any of the files do not conform to the style guide.",
-        action='store_true')
+    parser.add_argument("--overwrite",
+                        help="Overwrites the unformatted source files with the well-formatted code in place. "
+                        "If not set, an exception is raised if any of the files do not conform to the style guide.",
+                        action='store_true')
     args = parser.parse_args()
 
     overwrite = args.overwrite

--- a/pylint.rc
+++ b/pylint.rc
@@ -7,5 +7,5 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace
+disable=too-few-public-methods,len-as-condition
 

--- a/setup.py
+++ b/setup.py
@@ -15,29 +15,28 @@ here = os.path.abspath(os.path.dirname(__file__))  # pylint: disable=invalid-nam
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()  # pylint: disable=invalid-name
 
-setup(
-    name='reconnecting_ftp',
-    version='1.1.1',
-    description='Reconnecting FTP client',
-    long_description=long_description,
-    url='https://github.com/Parquery/reconnecting-ftp',
-    author='Marko Ristin',
-    author_email='marko@ristin.ch',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-    ],
-    keywords='ftplib reconnect retry robust ftp client',
-    packages=find_packages(exclude=['tests*']),
-    install_requires=[],
-    extras_require={
-        'test': ['pyftpdlib'],
-        'dev': ['mypy==0.910', 'pylint==2.11.1', 'yapf==0.20.2', 'pyftpdlib', 'coverage>=4.5.1,<5']
-    },
-    py_modules=['reconnecting_ftp'])
+setup(name='reconnecting_ftp',
+      version='1.1.1',
+      description='Reconnecting FTP client',
+      long_description=long_description,
+      url='https://github.com/Parquery/reconnecting-ftp',
+      author='Marko Ristin',
+      author_email='marko@ristin.ch',
+      classifiers=[
+          'Development Status :: 5 - Production/Stable',
+          'Intended Audience :: Developers',
+          'License :: OSI Approved :: MIT License',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
+      ],
+      keywords='ftplib reconnect retry robust ftp client',
+      packages=find_packages(exclude=['tests*']),
+      install_requires=[],
+      extras_require={
+          'test': ['pyftpdlib'],
+          'dev': ['mypy==1.4.1', 'pylint==2.17.7', 'yapf==0.40.2', 'pyftpdlib', 'coverage==7.2.7']
+      },
+      py_modules=['reconnecting_ftp'])

--- a/tests/test_reconnecting_ftp.py
+++ b/tests/test_reconnecting_ftp.py
@@ -91,13 +91,12 @@ class TestContext:
         self.homedir = pathlib.Path(tempfile.mkdtemp())
         self.exit_stack.callback(lambda: shutil.rmtree(self.homedir.as_posix()))
 
-        ftpd = ThreadedFTPServer(
-            hostname=self.hostname,
-            port=self.port,
-            timeout=self.timeout,
-            homedir=self.homedir,
-            user=self.user,
-            password=self.password)
+        ftpd = ThreadedFTPServer(hostname=self.hostname,
+                                 port=self.port,
+                                 timeout=self.timeout,
+                                 homedir=self.homedir,
+                                 user=self.user,
+                                 password=self.password)
 
         ftpd.__enter__()
         self.exit_stack.push(ftpd)
@@ -111,7 +110,6 @@ class TestContext:
 class TestReconnectingFTP(unittest.TestCase):
     # pylint: disable=missing-docstring
     def test_connect(self):
-        # pylint: disable=no-self-use
         with TestContext(port=find_free_port(), timeout=1) as ctx:
             ftp = reconnecting_ftp.Client(hostname=ctx.hostname, port=ctx.port, user=ctx.user, password=ctx.password)
 


### PR DESCRIPTION
Python 3.6 reached end-of-life, and is not supported by GitHub anymore. Hence, we can not test for it on the remote CI.

While we are at it, we added the support for Python 3.11. This, in turn, forced us to update development dependencies such as YAPF, Pylint *etc.*
