### PR TITLE
Added logic to retry on ConnectionError

### DIFF
--- a/reconnecting_ftp/__init__.py
+++ b/reconnecting_ftp/__init__.py
@@ -158,9 +158,8 @@ class Client:
                 assert self.connection is not None, "Expected connect() to either raise or create a connection"
                 return method(self.connection)
 
-            except (BrokenPipeError, ConnectionRefusedError, ConnectionAbortedError,
-                    socket.timeout, socket.gaierror, socket.herror,
-                    ftplib.error_temp, EOFError) as err:
+            except (ConnectionError, EOFError, ftplib.error_temp,
+                    socket.timeout, socket.gaierror, socket.herror) as err:
                 if self.connection is not None:
                     self.connection.close()
                     self.connection = None


### PR DESCRIPTION
following up on https://github.com/Parquery/reconnecting-ftp/pull/19

today my code failed with `ConnectionResetError`

i discovered that `BrokenPipeError` (which i recently added), `ConnectionRefusedError`, and `ConnectionAbortedError` and `ConnectionResetError` are subclasses of [`ConnectionError`](https://docs.python.org/3/library/exceptions.html#ConnectionError)

so replacing them with that