### PR TITLE
Released 1.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+1.1.2
+=====
+* Added logic to retry on ConnectionError (#21)
+* Added logic to retry on ``BrokenPipeError`` (#19)
+* Removed support for Python 3.6 and added for 3.11 (#20)
+* Added support for Python 3.10 (#16)
+
 1.1.1
 =====
 * Made encoding keyword backward compatible (#8)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()  # pylint: disable=invalid-name
 
 setup(name='reconnecting_ftp',
-      version='1.1.1',
+      version='1.1.2',
       description='Reconnecting FTP client',
       long_description=long_description,
       url='https://github.com/Parquery/reconnecting-ftp',


### PR DESCRIPTION
* Added logic to retry on ConnectionError (#21)
* Added logic to retry on ``BrokenPipeError`` (#19)
* Removed support for Python 3.6 and added for 3.11 (#20)
* Added support for Python 3.10 (#16)